### PR TITLE
Interactive prompt does not start when there is no config files

### DIFF
--- a/hypchat/__main__.py
+++ b/hypchat/__main__.py
@@ -1,13 +1,20 @@
 from . import *
 import os, os.path
 import ConfigParser
+import sys
 
 config = ConfigParser.ConfigParser()
 config.read([os.path.expanduser('~/.hypchat'), '/etc/hypchat'])
-AUTH_TOKEN = config.get('HipChat', 'token')
+if config.has_section('HipChat'):
+    AUTH_TOKEN = config.get('HipChat', 'token')
 
-if 'HIPCHAT_TOKEN' in os.environ:
-	AUTH_TOKEN = os.environ['HIPCHAT_TOKEN']
+elif 'HIPCHAT_TOKEN' in os.environ:
+    AUTH_TOKEN = os.environ['HIPCHAT_TOKEN']
+
+else:
+    print 'Authorization token not detected! The token is pulled from '\
+          '~/.hypchat, /etc/hypchat, or the environment variable HIPCHAT_TOKEN.'
+    sys.exit(1)
 
 hipchat = HypChat(AUTH_TOKEN)
 
@@ -17,8 +24,8 @@ rooms = hipchat.rooms
 users = hipchat.users
 
 try:
-	import IPython
-	IPython.embed()
+    import IPython
+    IPython.embed()
 except ImportError:
-	import code
-	code.interact(local=locals())
+    import code
+    code.interact(local=locals())


### PR DESCRIPTION
running the interactive prompt / 'python -m hypchat' gave an Traceback
when there was no configuration file(s) but the environment variable
was defined:

```
$ HIPCHAT_TOKEN=SvHG...... python -m hypchat
Traceback (most recent call last):
.....
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'HipChat'

$ vi  ~/.hypchat
$ cat  ~/.hypchat
[HipChat]
token = faketoke

$ HIPCHAT_TOKEN=SvHG...... python -m hypchat
Python 2.7.5 (default, Mar  9 2014, 22:15:05)
Type "copyright", "credits" or "license" for more information.

IPython 2.1.0 -- An enhanced Interactive Python.
?         -> Introduction and overview of IPython's features.
%quickref -> Quick reference.
help      -> Python's own help system.
object?   -> Details about 'object', use 'object??' for extra details.

In [1]: AUTH_TOKEN
Out[1]: 'SvHG......'
```
