### PR TITLE
Linker.call keyword arguments as parameters

### DIFF
--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -75,7 +75,11 @@ class Linker(object):
 				params = {'expand': expand}
 			else:
 				params = {'expand': ','.join(expand)}
-		params.update(kwargs)
+		if kwargs:
+			merge_params = {}
+			for k, v in kwargs.iteritems():
+				merge_params[k.replace('_', '-')] = v
+			params.update(merge_params)
 
 		rv = self._obj_from_text(self._requests.get(self.url, params=params).text, self._requests)
 		rv._requests = self._requests


### PR DESCRIPTION
This shouldn't change any existing functionality, but it does cause the local `params` in `Linker.__call__` to become an empty dictionary, by default, instead of `None`.

That aside, keyword arguments (other than `expand`) given to `Linker.__call__` will now be passed as query parameters, which is useful for calls like:

```
hc.emoticons(type='group')
hc.rooms(include_archived=True)
```

Note the use of an underscore instead of a dash; the conversion is done automatically.
