### PR TITLE
Support the message_format and notify parameters in the private message ...

### DIFF
--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -196,12 +196,14 @@ class User(RestObject):
 		if 'created' in self:
 			self['created'] = timestamp(self['created'])
 
-	def message(self, message):
+	def message(self, message, message_format='text', notify=False):
 		"""
 		Sends a user a private message.
 		"""
 		self._requests.post(self.url+'/message', data={
 			'message': message,
+			'message_format': message_format,
+			'notify': notify,
 		})
 
 	def save(self):


### PR DESCRIPTION
...REST api

Though currently only the web client supports the html message format, I'd expect wider client support in the future.
