### PR TITLE
Implemented Room message and reply methods

### DIFF
--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -132,6 +132,13 @@ class Room(RestObject):
 		}
 		self._requests.put(self.url, data=data)
 
+	def reply(self, message, parent_message_id):
+		"""
+		Send a reply to a message
+		"""
+		data = {'message': message, 'parentMessageId': parent_message_id}
+		self._requests.post(self.url+'/reply', data=data)
+
 	def message(self, *p, **kw):
 		"""
 		Redirects to the /notification URL.

--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -139,13 +139,11 @@ class Room(RestObject):
 		data = {'message': message, 'parentMessageId': parent_message_id}
 		self._requests.post(self.url+'/reply', data=data)
 
-	def message(self, *p, **kw):
+	def message(self, message):
 		"""
-		Redirects to the /notification URL.
-
-		Will soon be reimplemented as a resource that posts a message to a room as a user.
+		Redirects to the /reply URL with an empty parentMessageId
 		"""
-		return self.notification(*p, **kw)
+		return self.reply(message, parent_message_id='')
 
 	def notification(self, message, color=None, notify=False, format=None):
 		"""


### PR DESCRIPTION
Since the room message API call is a subset of the notification call, it makes more sense to redirect to the reply call (with an empty `parentMessageId`) which looks more like a standard user message.