### PR TITLE
add expand=... to users() method on HypChat()

### DIFF
--- a/hypchat/__init__.py
+++ b/hypchat/__init__.py
@@ -105,6 +105,8 @@ class HypChat(object):
             params['include-guests'] = 'true'
         if ops.get('deleted', False):
             params['include-deleted'] = 'true'
+        if 'expand' in ops:
+            params['expand'] = ops['expand']
         resp = self._requests.get(self.users_url, params=params)
         return Linker._obj_from_text(resp.text, self._requests)
 


### PR DESCRIPTION
I'm doing some user management with this excellent library, but I keep hitting
the request limit when I don't use the expand.  I didn't see a clear way to
do this otherwise.
