### PR TITLE
Add a send_notification method for notification-only tokens (issue #46) to the HypChat class.

### DIFF
--- a/hypchat/__init__.py
+++ b/hypchat/__init__.py
@@ -7,7 +7,7 @@ import os
 import datetime
 import six
 from .requests import Requests, BearerAuth, HttpTooManyRequests
-from .restobject import Linker
+from .restobject import Linker, prepare_notification_data
 
 
 class RateLimitWarning(Warning):
@@ -155,3 +155,12 @@ class HypChat(object):
 
     def get_emoticon(self, id_or_shortcut, **kwargs):
         return self.fromurl('{0}/v2/emoticon/{1}'.format(self.endpoint, id_or_shortcut), **kwargs)
+
+    def send_notification(self, id_or_name, message, notify=False, format=None, **kwargs):
+        """
+        Send a message to a room.
+        This version is for notification-only add-ons and tokens generated for that purpose.
+        """
+        data = prepare_notification_data(message, notify, format, **kwargs)
+        url = '{0}/v2/room/{1}'.format(self.endpoint, id_or_name)
+        self._requests.post(url + '/notification', data=data)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
-from distutils.core import setup, Command
+from setuptools import setup, Command
+
 
 
 class PyTest(Command):


### PR DESCRIPTION
Not 100% satisfied but I needed something quick
