### PR TITLE
Added try except forn CongiParser inport to allow py3 to work

### DIFF
--- a/hypchat/__main__.py
+++ b/hypchat/__main__.py
@@ -1,6 +1,9 @@
 from . import *
 import os, os.path
-import ConfigParser
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 import sys
 
 config = ConfigParser.ConfigParser()


### PR DESCRIPTION
Allows the `python -m hypchat` command to work in python3
