### PR TITLE
Message reply and card support

### DIFF
--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -148,7 +148,7 @@ class Room(RestObject):
         resp = self._requests.post(self.url + '/message', data=data)
         return Linker._obj_from_text(resp.text, self._requests)
 
-    def notification(self, message, color=None, notify=False, format=None):
+    def notification(self, message, card=None, color=None, notify=False, format=None):
         """
         Send a message to a room.
         """
@@ -157,7 +157,7 @@ class Room(RestObject):
                 format = 'text'
             else:
                 format = 'html'
-        data = {'message': message, 'notify': notify, 'message_format': format}
+        data = {'message': message, 'card': card, 'notify': notify, 'message_format': format}
         if color:
             data['color'] = color
         self._requests.post(self.url + '/notification', data=data)

--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -145,7 +145,8 @@ class Room(RestObject):
         Allows a user to send a message to a room.
         """
         data = {'message': message}
-        self._requests.post(self.url + '/message', data=data)
+        resp = self._requests.post(self.url + '/message', data=data)
+        return Linker._obj_from_text(resp.text, self._requests)
 
     def notification(self, message, color=None, notify=False, format=None):
         """

--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -148,7 +148,7 @@ class Room(RestObject):
         resp = self._requests.post(self.url + '/message', data=data)
         return Linker._obj_from_text(resp.text, self._requests)
 
-    def notification(self, message, card=None, color=None, notify=False, format=None, attach_to=None):
+    def notification(self, message, color=None, notify=False, format=None, card=None, attach_to=None):
         """
         Send a message to a room.
         """
@@ -157,9 +157,13 @@ class Room(RestObject):
                 format = 'text'
             else:
                 format = 'html'
-        data = {'message': message, 'card': card, 'notify': notify, 'message_format': format, 'attach_to': attach_to}
+        data = {'message': message, 'notify': notify, 'message_format': format}
         if color:
             data['color'] = color
+        if card:
+            data['card'] = card
+        if attach_to:
+            data['attach_to'] = attach_to
         self._requests.post(self.url + '/notification', data=data)
 
     def topic(self, text):

--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -148,7 +148,7 @@ class Room(RestObject):
         resp = self._requests.post(self.url + '/message', data=data)
         return Linker._obj_from_text(resp.text, self._requests)
 
-    def notification(self, message, card=None, color=None, notify=False, format=None):
+    def notification(self, message, card=None, color=None, notify=False, format=None, attach_to=None):
         """
         Send a message to a room.
         """
@@ -157,7 +157,7 @@ class Room(RestObject):
                 format = 'text'
             else:
                 format = 'html'
-        data = {'message': message, 'card': card, 'notify': notify, 'message_format': format}
+        data = {'message': message, 'card': card, 'notify': notify, 'message_format': format, 'attach_to': attach_to}
         if color:
             data['color'] = color
         self._requests.post(self.url + '/notification', data=data)


### PR DESCRIPTION
With these changes, you can send a message to a room, get the message id from the response, and add a reply and attach a card, all nice and contained. For example:

``` python
my_room = hc.get_room('Test Room')
resp = my_room.message('Check this out @all!')
my_room.reply("You can add cards with HypChat!", resp['id'])
my_room.notification('This is a fallback message', card=my_fancy_card_dict, attach_to=resp['id'])
```

The card will slide right on top of the reply, attached to the first message!

Constructing `my_fancy_card_dict` is left as an exercise for the reader, but reading [Sending Messages Using Cards](https://developer.atlassian.com/hipchat/guide/sending-messages#SendingMessages-UsingCards) should help.
