### PR TITLE
Added option to specify the from property in a room's notification

### DIFF
--- a/hypchat/restobject.py
+++ b/hypchat/restobject.py
@@ -147,7 +147,7 @@ class Room(RestObject):
         data = {'message': message}
         self._requests.post(self.url + '/message', data=data)
 
-    def notification(self, message, color=None, notify=False, format=None):
+    def notification(self, message, color=None, notify=False, format=None, from_label=None):
         """
         Send a message to a room.
         """
@@ -159,6 +159,11 @@ class Room(RestObject):
         data = {'message': message, 'notify': notify, 'message_format': format}
         if color:
             data['color'] = color
+        if from_label:
+            if len(from_label) > 64:
+                data['from'] = from_label[:64]
+            else:
+                data['from'] = from_label
         self._requests.post(self.url + '/notification', data=data)
 
     def topic(self, text):


### PR DESCRIPTION
The from property is a label to be shown in addition to the sender's name. There is a 64 character limit constraint on this label. It will take the first 64 if more are  provided. 

`room.notification(message="This notification has a label", from_label="A label")`